### PR TITLE
Fix compile error for Mbed TF-M V8M target

### DIFF
--- a/source/platform/mbed-os/mcc_common_setup.cpp
+++ b/source/platform/mbed-os/mcc_common_setup.cpp
@@ -386,11 +386,14 @@ void mcc_platform_sw_build_info(void) {
 int mcc_platform_storage_init(void) {
     // This wait will allow the board more time to initialize
     mcc_platform_do_wait(MCC_PLATFORM_WAIT_BEFORE_BD_INIT * SECONDS_TO_MS);
+    // Normally, TF-M V8M targets don't support KVStore/FLASHIAP and change to PSA Storage API instead.
+#if DEVICE_FLASH
     int status = kv_init_storage_config();
     if (status != MBED_SUCCESS) {
         printf("kv_init_storage_config() - failed, status %d\n", status);
         return status;
     }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x] I confirm the moderators may change the PR before merging it in.
[x] I understand the release model prohibits detailed Git history and my contribution will be recorded to the list at the bottom of [CONTRIBUTING.md](CONTRIBUTING.md).


### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

Use `DEVICE_FLASH` to exclude `KVStore`/`FLASHIAP` code for Mbed TF-M V8M target, usually without `FLASHIAP`.

