### PR TITLE
.mbedignore - add venv folder

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -2,3 +2,4 @@ __*/*
 pal-platform/*
 storage-selector/littlefs/*
 delta-tool/*
+venv/*


### PR DESCRIPTION
This will create some nasty surprises in case you do a "proper clean installation of Python 2" for mbed cli (in case you want to run Mbed OS 5.15.x).
I.e. 

``
virtualenv venv -p /usr/bin/python2.7
pip install mbed-cli
pip install mbed-os/requirements.txt
``` 

It will try to compile EVERYTHING - as per usual and then fails when it does not find various Python compilation things.

```
Compile [ 97.3%]: _speedups.c
[Error] pyconfig.h@122,3: #error unknown multiarch location for pyconfig.h
[Error] pyconfig.h@122,3: #error unknown multiarch location for pyconfig.h
[Error] pyconfig.h@122,3: #error unknown multiarch location for pyconfig.h
[Error] _speedups.c@18,8: unknown type name 'Py_UNICODE'
1:32
```

Took a good while for me to figure it out...  :-(

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[] I confirm the moderators may change the PR before merging it in.
[] I understand the release model prohibits detailed Git history and my contribution will be recorded to the list at the bottom of [CONTRIBUTING.md](CONTRIBUTING.md).


### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

